### PR TITLE
Fix connectToFramework switch case

### DIFF
--- a/articles/includes/code/dotnet-formflow.cs
+++ b/articles/includes/code/dotnet-formflow.cs
@@ -79,6 +79,7 @@ public virtual async Task<HttpResponseMessage> Post([FromBody] Activity activity
             case ActivityTypes.DeleteUserData:
             default:
                 Trace.TraceError($"Unknown activity type ignored: {activity.GetActivityType()}");
+                break;
         }
     }
     ...


### PR DESCRIPTION
There should be a break-statement at the end of the default case, since it may not compile at all and can be especially confusing for newcomers to C#.