### PR TITLE
Update bot-builder-dotnet-quickstart.md

### DIFF
--- a/articles/dotnet/bot-builder-dotnet-quickstart.md
+++ b/articles/dotnet/bot-builder-dotnet-quickstart.md
@@ -36,8 +36,9 @@ Get started by completing the following prerequisite tasks:
 
 2. In Visual Studio, <a href="https://docs.microsoft.com/en-us/visualstudio/extensibility/how-to-update-a-visual-studio-extension" target="_blank">update all extensions</a> to their latest versions.
 
-4. [Download](http://aka.ms/bf-bc-vstemplate) the Bot Application template
+4. Download the [Bot Application](http://aka.ms/bf-bc-vstemplate), [Bot Controller](http://aka.ms/bf-bc-vscontrollertemplate), and [Bot Dialog](http://aka.ms/bf-bc-vsdialogtemplate) templates
 and install the template by saving the .zip file to your Visual Studio 2017 project templates directory.  
+
 > [!TIP]
 > The Visual Studio 2017 project templates directory is typically located here:
 > `%USERPROFILE%\Documents\Visual Studio 2017\Templates\ProjectTemplates\Visual C#\`


### PR DESCRIPTION
Restoring links to the controller & dialog templates that were present in previous documentation