### PR TITLE
Changed AttachmentLayouts to AttachmentLayoutTypes

### DIFF
--- a/articles/includes/code/dotnet-add-attachments.cs
+++ b/articles/includes/code/dotnet-add-attachments.cs
@@ -11,7 +11,7 @@ replyMessage.Attachments.Add(new Attachment()
 
 // <addHeroCardAttachment>
 Activity replyToConversation = message.CreateReply("Should go to conversation, in carousel format");
-replyToConversation.AttachmentLayout = AttachmentLayouts.Carousel;
+replyToConversation.AttachmentLayout = AttachmentLayoutTypes.Carousel;
 replyToConversation.Attachments = new List<Attachment>();
 
 Dictionary<string, string> cardContentList = new Dictionary<string, string>();
@@ -54,7 +54,7 @@ var reply = await connector.Conversations.SendToConversationAsync(replyToConvers
 
 // <addThumbnailCardAttachment>
 Activity replyToConversation = message.CreateReply("Should go to conversation, in list format");
-replyToConversation.AttachmentLayout = AttachmentLayouts.List;
+replyToConversation.AttachmentLayout = AttachmentLayoutTypes.List;
 replyToConversation.Attachments = new List<Attachment>();
 
 Dictionary<string, string> cardContentList = new Dictionary<string, string>();


### PR DESCRIPTION
The types of Attachment Layouts class is called AttachmentLayoutTypes and not AttachmentLayouts.
https://docs.botframework.com/en-us/csharp/builder/sdkreference/d7/d87/class_microsoft_1_1_bot_1_1_connector_1_1_attachment_layout_types.html